### PR TITLE
test: adicionar testes unitários de OrderService com repositórios in-memory

### DIFF
--- a/src/repository/in-memory/cart.ts
+++ b/src/repository/in-memory/cart.ts
@@ -166,7 +166,13 @@ class InMemoryCartRepository implements ICartRepository {
     }));
   };
 
-  changeStatusCart!: (idCart: string) => Promise<void>;
+  changeStatusCart = async (idCart: string, status: StatusCart) => {
+    const cart = this.cartDb.find((data) => data.id === idCart);
+
+    if (cart) {
+      cart.status = status;
+    }
+  };
 }
 
 export { InMemoryCartRepository };

--- a/src/repository/in-memory/order.ts
+++ b/src/repository/in-memory/order.ts
@@ -1,0 +1,191 @@
+import { IOrderRepository, ListAllOrdersPaginated } from "@/repository/interfaces";
+import {
+  DashboardQuickStats,
+  DashboardRevenueDto,
+  DashboardSummaryDto,
+  ListOrderByIdDto,
+  OrderCreateReturnDto,
+  OrderEntity,
+  ReturnUpdateOrderAdmin,
+  ReturnUpdateOrderDto,
+} from "@/domain/model/OrderEntity";
+import { OrderDto, UpdateOrderDto } from "@/domain/dto/order/OrderDto";
+import { DashboardQueryParams, ListQueryOrdersDto } from "@/utils/zod/schemas/params";
+import { Decimal } from "@prisma/client/runtime/library";
+import { StatusOrder } from "@prisma/client";
+import { randomUUID } from "crypto";
+
+class InMemoryOrderRepository implements IOrderRepository {
+  ordersDb: Array<ListOrderByIdDto & { usuarioId: string; createdBy: string | null }> = [];
+
+  createOrder = async (orderDto: OrderDto, currentPrice: Decimal, createdBy: string): Promise<OrderCreateReturnDto> => {
+    const order = this.makeOrder(orderDto, currentPrice, createdBy);
+    this.ordersDb.push(order);
+
+    return {
+      id: order.id,
+      numeroPedido: order.numeroPedido,
+      status: order.status,
+      createdAt: new Date(),
+    };
+  };
+
+  updateOrder = async (id: string, order: UpdateOrderDto): Promise<ReturnUpdateOrderDto> => {
+    const found = this.ordersDb.find((item) => item.id === id);
+
+    if (!found) return null as never;
+
+    found.observacao = order.observation ?? found.observacao;
+    found.dataAgendamento = order.schedulingDate ?? found.dataAgendamento;
+    found.horarioInicio = order.startTime ?? found.horarioInicio;
+    found.horarioFim = order.endTime ?? found.horarioFim;
+
+    return {
+      id: found.id,
+      numeroPedido: found.numeroPedido,
+      precoTotal: found.precoTotal,
+      status: found.status,
+      observacao: found.observacao,
+      dataAgendamento: found.dataAgendamento!,
+      horarioInicio: found.horarioInicio,
+      horarioFim: found.horarioFim,
+      metodoPagamento: found.metodoPagamento,
+      updatedAt: new Date(),
+    };
+  };
+
+  adminUpdateOrder = async (id: string, order: UpdateOrderDto, totalPrice: Decimal): Promise<ReturnUpdateOrderAdmin> => {
+    const found = this.ordersDb.find((item) => item.id === id);
+
+    if (!found) return null as never;
+
+    found.precoTotal = totalPrice;
+    found.frete = new Decimal(order.shipping || found.frete);
+
+    return {
+      id: found.id,
+      numeroPedido: found.numeroPedido,
+      precoTotal: found.precoTotal,
+      status: found.status,
+      observacao: found.observacao,
+      dataAgendamento: found.dataAgendamento!,
+      horarioInicio: found.horarioInicio,
+      horarioFim: found.horarioFim,
+      metodoPagamento: found.metodoPagamento,
+      frete: found.frete,
+      usuario: found.usuario,
+      endereco: found.endereco,
+      updatedAt: new Date(),
+    };
+  };
+
+  cancelOrder = async (id: string): Promise<{ id: string }> => {
+    const found = this.ordersDb.find((item) => item.id === id);
+    if (found) found.status = StatusOrder.CANCELADO;
+    return { id };
+  };
+
+  listOrdersByClientId = async (idClient: string): Promise<Partial<OrderEntity>[]> => {
+    return this.ordersDb.filter((order) => order.usuarioId === idClient) as unknown as Partial<OrderEntity>[];
+  };
+
+  listOrdersMe = async (idClient: string): Promise<Partial<OrderEntity>[]> => {
+    return this.ordersDb.filter((order) => order.usuarioId === idClient) as unknown as Partial<OrderEntity>[];
+  };
+
+  listAllOrders = async (_params: ListQueryOrdersDto): Promise<ListAllOrdersPaginated> => {
+    return {
+      data: [] as any,
+      page: 1,
+      size: 10,
+      totalItems: this.ordersDb.length,
+      totalPages: 1,
+    };
+  };
+
+  listOrderById = async (id: string): Promise<ListOrderByIdDto | null> => {
+    return this.ordersDb.find((order) => order.id === id) || null;
+  };
+
+  changeStatusOrder = async (id: string, status: StatusOrder): Promise<{ id: string; usuarioId: string | null }> => {
+    const found = this.ordersDb.find((item) => item.id === id);
+    if (found) found.status = status;
+    return { id, usuarioId: found?.usuarioId || null };
+  };
+
+  updateShippingOrder = async (idOrder: string, price: Decimal): Promise<Partial<OrderEntity>> => {
+    const found = this.ordersDb.find((item) => item.id === idOrder);
+    if (found) {
+      found.frete = price;
+      found.precoTotal = found.carrinho.valorTotal!.plus(price);
+    }
+    return (found || {}) as Partial<OrderEntity>;
+  };
+
+  getDashboardSummary = async (_query: DashboardQueryParams): Promise<DashboardSummaryDto> => {
+    return {
+      totalRevenue: 0,
+      totalOrders: this.ordersDb.length,
+      orderInProgress: 0,
+      cancelOrders: this.ordersDb.filter((item) => item.status === StatusOrder.CANCELADO).length,
+      orderDelivered: 0,
+    };
+  };
+
+  getDashboardRevenue = async (_query: DashboardQueryParams): Promise<DashboardRevenueDto[] | null> => {
+    return [];
+  };
+
+  getDashboardQuickSats = async (): Promise<DashboardQuickStats> => {
+    return {
+      ordersScheduledToday: 0,
+      deliveriesDueToday: 0,
+      canceledToday: 0,
+      totalDelivered: 0,
+      inProgressOrdersToday: 0,
+    };
+  };
+
+  private makeOrder(orderDto: OrderDto, currentPrice: Decimal, createdBy: string) {
+    return {
+      id: randomUUID(),
+      numeroPedido: this.ordersDb.length + 1,
+      status: orderDto.status,
+      observacao: orderDto.observation || null,
+      precoTotal: currentPrice,
+      frete: new Decimal(orderDto.shipping),
+      dataAgendamento: orderDto.schedulingDate,
+      horarioInicio: orderDto.startTime,
+      horarioFim: orderDto.endTime,
+      celularCliente: orderDto.cellphoneClient || null,
+      nomeCliente: orderDto.nameClient || null,
+      metodoPagamento: {
+        id: orderDto.idPaymentMethod,
+        nome: "Pix",
+      },
+      usuario: {
+        nome: "Usuário teste",
+        telefone: "00000000000",
+        email: "user@example.com",
+      },
+      carrinho: {
+        status: "ATIVO",
+        valorTotal: currentPrice.minus(new Decimal(orderDto.shipping)),
+        carrinhoItens: [],
+      },
+      endereco: {
+        bairro: "Centro",
+        cidade: "Cidade",
+        cep: "00000000",
+        complemento: null,
+        estado: "SP",
+        numero: "123",
+        rua: "Rua Teste",
+      },
+      usuarioId: orderDto.idUser,
+      createdBy,
+    };
+  }
+}
+
+export { InMemoryOrderRepository };

--- a/src/service/order/OrderService.spec.ts
+++ b/src/service/order/OrderService.spec.ts
@@ -13,6 +13,7 @@ describe("Unit test - OrderService", () => {
 
   const userId = randomUUID();
   const cartId = randomUUID();
+  const requesterEmail = "admin@example.com";
 
   const createOrderDto = (overrides: Partial<OrderDto> = {}): OrderDto => ({
     idUser: userId,
@@ -46,15 +47,16 @@ describe("Unit test - OrderService", () => {
         valorTotal: new Decimal(80),
       });
 
-      const order = await orderService.createOrder(createOrderDto(), userId);
+      const order = await orderService.createOrder(createOrderDto(), requesterEmail);
 
       expect(order.id).toBeTruthy();
       expect(order.status).toBe(StatusOrder.PENDENTE);
+      expect(orderRepositoryInMemory.ordersDb[0].createdBy).toBe(requesterEmail);
       expect(cartRepositoryInMemory.cartDb[0].status).toBe(StatusCart.FINALIZADO);
     });
 
     it("should throw error if cart does not exist", async () => {
-      await expect(orderService.createOrder(createOrderDto(), userId)).rejects.toThrow("carrinho não encontrado");
+      await expect(orderService.createOrder(createOrderDto(), requesterEmail)).rejects.toThrow("carrinho não encontrado");
     });
 
     it("should throw error when scheduling date is invalid", async () => {
@@ -67,7 +69,7 @@ describe("Unit test - OrderService", () => {
       });
 
       await expect(
-        orderService.createOrder(createOrderDto({ schedulingDate: new Date("invalid") }), userId),
+        orderService.createOrder(createOrderDto({ schedulingDate: new Date("invalid") }), requesterEmail),
       ).rejects.toThrow("Data de agendamento inválida");
     });
   });
@@ -75,7 +77,7 @@ describe("Unit test - OrderService", () => {
   describe("updateOrder", () => {
     it("should update existing order", async () => {
       const dto = createOrderDto();
-      const created = await orderRepositoryInMemory.createOrder(dto, new Decimal(90), userId);
+      const created = await orderRepositoryInMemory.createOrder(dto, new Decimal(90), requesterEmail);
 
       const updated = await orderService.updateOrder(created.id, {
         observation: "Trocar recheio",
@@ -93,7 +95,7 @@ describe("Unit test - OrderService", () => {
   describe("cancelOrder", () => {
     it("should cancel order if requested at least 24h before", async () => {
       const dto = createOrderDto();
-      const created = await orderRepositoryInMemory.createOrder(dto, new Decimal(90), userId);
+      const created = await orderRepositoryInMemory.createOrder(dto, new Decimal(90), requesterEmail);
 
       const result = await orderService.cancelOrder(created.id);
 
@@ -102,7 +104,7 @@ describe("Unit test - OrderService", () => {
 
     it("should not cancel an already canceled order", async () => {
       const dto = createOrderDto({ status: StatusOrder.CANCELADO });
-      const created = await orderRepositoryInMemory.createOrder(dto, new Decimal(90), userId);
+      const created = await orderRepositoryInMemory.createOrder(dto, new Decimal(90), requesterEmail);
 
       await expect(orderService.cancelOrder(created.id)).rejects.toThrow("Pedido já está cancelado");
     });
@@ -115,7 +117,7 @@ describe("Unit test - OrderService", () => {
 
     it("should list order by id and change status", async () => {
       const dto = createOrderDto();
-      const created = await orderRepositoryInMemory.createOrder(dto, new Decimal(90), userId);
+      const created = await orderRepositoryInMemory.createOrder(dto, new Decimal(90), requesterEmail);
 
       const orderById = await orderService.listOrderById(created.id);
       const statusChanged = await orderService.changeStatusOrder(created.id, StatusOrder.PREPARANDO);

--- a/src/service/order/OrderService.spec.ts
+++ b/src/service/order/OrderService.spec.ts
@@ -1,0 +1,128 @@
+import { InMemoryCartRepository } from "@/repository/in-memory/cart";
+import { InMemoryOrderRepository } from "@/repository/in-memory/order";
+import { OrderService } from "./Order.service";
+import { OrderDto, UpdateOrderDto } from "@/domain/dto/order/OrderDto";
+import { Decimal } from "@prisma/client/runtime/library";
+import { StatusCart, StatusOrder } from "@prisma/client";
+import { randomUUID } from "crypto";
+
+describe("Unit test - OrderService", () => {
+  let cartRepositoryInMemory: InMemoryCartRepository;
+  let orderRepositoryInMemory: InMemoryOrderRepository;
+  let orderService: OrderService;
+
+  const userId = randomUUID();
+  const cartId = randomUUID();
+
+  const createOrderDto = (overrides: Partial<OrderDto> = {}): OrderDto => ({
+    idUser: userId,
+    idCart: cartId,
+    idAddress: randomUUID(),
+    idPaymentMethod: randomUUID(),
+    status: StatusOrder.PENDENTE,
+    schedulingDate: new Date(Date.now() + 1000 * 60 * 60 * 26),
+    startTime: "10:00",
+    endTime: "11:00",
+    observation: "Sem cebola",
+    shipping: "10",
+    nameClient: "Gabriel",
+    cellphoneClient: "11999999999",
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    cartRepositoryInMemory = new InMemoryCartRepository();
+    orderRepositoryInMemory = new InMemoryOrderRepository();
+    orderService = new OrderService(orderRepositoryInMemory, cartRepositoryInMemory);
+  });
+
+  describe("createOrder", () => {
+    it("should create order and finalize active cart", async () => {
+      cartRepositoryInMemory.cartDb.push({
+        id: cartId,
+        status: StatusCart.ATIVO,
+        createdAt: new Date(),
+        usuarioId: userId,
+        valorTotal: new Decimal(80),
+      });
+
+      const order = await orderService.createOrder(createOrderDto(), userId);
+
+      expect(order.id).toBeTruthy();
+      expect(order.status).toBe(StatusOrder.PENDENTE);
+      expect(cartRepositoryInMemory.cartDb[0].status).toBe(StatusCart.FINALIZADO);
+    });
+
+    it("should throw error if cart does not exist", async () => {
+      await expect(orderService.createOrder(createOrderDto(), userId)).rejects.toThrow("carrinho não encontrado");
+    });
+
+    it("should throw error when scheduling date is invalid", async () => {
+      cartRepositoryInMemory.cartDb.push({
+        id: cartId,
+        status: StatusCart.ATIVO,
+        createdAt: new Date(),
+        usuarioId: userId,
+        valorTotal: new Decimal(80),
+      });
+
+      await expect(
+        orderService.createOrder(createOrderDto({ schedulingDate: new Date("invalid") }), userId),
+      ).rejects.toThrow("Data de agendamento inválida");
+    });
+  });
+
+  describe("updateOrder", () => {
+    it("should update existing order", async () => {
+      const dto = createOrderDto();
+      const created = await orderRepositoryInMemory.createOrder(dto, new Decimal(90), userId);
+
+      const updated = await orderService.updateOrder(created.id, {
+        observation: "Trocar recheio",
+      } as UpdateOrderDto);
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.observacao).toBe("Trocar recheio");
+    });
+
+    it("should throw error when order does not exist", async () => {
+      await expect(orderService.updateOrder("invalid-id", {} as UpdateOrderDto)).rejects.toThrow("Pedido não encontrado");
+    });
+  });
+
+  describe("cancelOrder", () => {
+    it("should cancel order if requested at least 24h before", async () => {
+      const dto = createOrderDto();
+      const created = await orderRepositoryInMemory.createOrder(dto, new Decimal(90), userId);
+
+      const result = await orderService.cancelOrder(created.id);
+
+      expect(result.id).toBe(created.id);
+    });
+
+    it("should not cancel an already canceled order", async () => {
+      const dto = createOrderDto({ status: StatusOrder.CANCELADO });
+      const created = await orderRepositoryInMemory.createOrder(dto, new Decimal(90), userId);
+
+      await expect(orderService.cancelOrder(created.id)).rejects.toThrow("Pedido já está cancelado");
+    });
+  });
+
+  describe("list and status methods", () => {
+    it("should throw when user has no orders", async () => {
+      await expect(orderService.listOrdersMe(userId)).rejects.toThrow("Você não possui nenhum pedido");
+    });
+
+    it("should list order by id and change status", async () => {
+      const dto = createOrderDto();
+      const created = await orderRepositoryInMemory.createOrder(dto, new Decimal(90), userId);
+
+      const orderById = await orderService.listOrderById(created.id);
+      const statusChanged = await orderService.changeStatusOrder(created.id, StatusOrder.PREPARANDO);
+
+      expect(orderById.id).toBe(created.id);
+      expect(statusChanged.id).toBe(created.id);
+      expect(orderRepositoryInMemory.ordersDb[0].status).toBe(StatusOrder.PREPARANDO);
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Fornecer cobertura de testes unitários para `OrderService` seguindo o padrão do projeto que usa repositórios em memória como mock.

### Description
- Adicionado `InMemoryOrderRepository` em `src/repository/in-memory/order.ts` com implementações mínimas para criação, atualização, cancelamento, listagens, mudança de status e helpers de dashboard.
- Implementado `changeStatusCart` em `InMemoryCartRepository` (`src/repository/in-memory/cart.ts`) para permitir validações de transição de status do carrinho durante os testes.
- Adicionado o spec `src/service/order/OrderService.spec.ts` cobrindo `createOrder`, `updateOrder`, `cancelOrder`, `listOrdersMe`, `listOrderById` e `changeStatusOrder` com cenários de sucesso e de falha.

### Testing
- Executado `npm test -- src/service/order/OrderService.spec.ts` e a suíte passou com sucesso.
- Executado `npm test -- src/service/order/OrderService.spec.ts src/service/cart/CartService.spec.ts src/service/auth/authService.spec.ts src/service/itens/ItemService.spec.ts` e todas as suítes rodadas passaram; resumo: `4` test suites passed, `39` tests passed, `5` skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a9847a544832cad11a696776510c1)