### PR TITLE
fix: type express error handler middleware signature

### DIFF
--- a/src/middlewares/error/error-handler-middleware.ts
+++ b/src/middlewares/error/error-handler-middleware.ts
@@ -2,7 +2,7 @@
 
 import { HttpStatus } from "@/shared/constants";
 import { formatZodErroMessage, isZodError } from "../../shared/error/zod";
-import { Request, NextFunction, Response } from "express";
+import { ErrorRequestHandler } from "express";
 import { formartErroPrisma, isPrismaError } from "@/shared/error/prisma";
 import { ExternalServiceUnauthorizedException } from "@/shared/error/exceptions/unauthorizedInternal-exception";
 
@@ -40,35 +40,39 @@ class ErrorHandlerMiddleware {
       message: error.message,
     };
   }
-  handle = (error: Error, req: Request, res: Response, next: NextFunction) => {
+  handle: ErrorRequestHandler = (error, req, res, next) => {
     if (isZodError(error)) {
       const formatted = formatZodErroMessage(error);
-      return res.status(HttpStatus.BAD_REQUEST).json({
+      res.status(HttpStatus.BAD_REQUEST).json({
         message: "Dados inválidos",
         errors: formatted.errors,
       });
+      return;
     }
 
     if (isPrismaError(error)) {
       const prismaError = formartErroPrisma(error);
-      return res.status(prismaError.errors.status).json({
+      res.status(prismaError.errors.status).json({
         message: prismaError.message,
       });
+      return;
     }
 
     const parsedError = this.parseError(error);
 
     if (error instanceof ExternalServiceUnauthorizedException) {
-      return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+      res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
         message: "Não foi possível seguir com a ação. Tente novamente mais tarde.",
       });
+      return;
     }
 
     if (parsedError.status === HttpStatus.INTERNAL_SERVER_ERROR) {
-      return res.status(parsedError.status).json({ message: "Erro inesperado no servidor. Entre contato com suporte" });
+      res.status(parsedError.status).json({ message: "Erro inesperado no servidor. Entre contato com suporte" });
+      return;
     }
 
-    return res.status(parsedError.status).json({
+    res.status(parsedError.status).json({
       message: parsedError.message,
     });
   };


### PR DESCRIPTION
### Motivation
- Corrigir o erro de tipagem TypeScript que ocorria ao registrar o middleware de erro com `app.use(errorHandlerMiddleware.handle)` devido à assinatura inferida incorreta da função.

### Description
- Altera a importação para usar `ErrorRequestHandler` do Express e tipa `ErrorHandlerMiddleware.handle` como `ErrorRequestHandler`.
- Remove retornos diretos de `Response` no handler e passa a apenas enviar a resposta com `res.status(...).json(...)` seguido de `return;` para tornar o retorno `void` compatível com o contrato de middleware de erro.
- Arquivo modificado: `src/middlewares/error/error-handler-middleware.ts`.

### Testing
- Executei `npm run build` e o processo falhou por vários erros existentes no repositório que não são relacionados a esta alteração; a falha foi observada e documentada.
- Executei `npx tsc --noEmit` direcionado a `src/infra/server/app.ts` e `src/middlewares/error/error-handler-middleware.ts` e verifiquei que a incompatibilidade de sobrecarga ao usar `app.use(errorHandlerMiddleware.handle)` foi resolvida, embora o restante do projeto ainda apresente erros de tipagem e configurações que permanecem fora do escopo desta correção.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aa58e4b54832c9f7eb347b819f908)