### PR TITLE
docs: replace minimal README with detailed technical overview and architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,243 @@
-## Projeto Encomenda/Pedido - Backend
-Este é o backend da aplicação de pedidos e agendamentos de comida. A API foi desenvolvida para dar suporte ao frontend, permitindo cadastro de clientes, login, criação e listagem de pedidos, além de funcionalidades administrativas.
+# Projeto Encomenda/Pedido - Backend
 
-🔧 Tecnologias utilizadas
+Backend em **Node.js + TypeScript** para gestão de autenticação, catálogo de itens, carrinho, pedidos agendados, frete e dashboard administrativo.
+
+> Este README foi escrito para avaliação técnica, com foco em **decisões arquiteturais e de engenharia** tomadas no projeto e o motivo de cada uma delas.
+
+---
+
+## 1) Objetivo técnico do projeto
+
+O projeto foi estruturado para resolver um cenário real de e-commerce de alimentação com:
+
+- regras de negócio de pedido (janela de horário, agendamento e status);
+- autenticação com sessão baseada em cookies + JWT;
+- integração com serviços externos (frete e e-mail);
+- rastreabilidade operacional (logs + request id);
+- capacidade de evolução para cenários com mais carga (Redis para rate limit e arquitetura em camadas).
+
+A decisão central foi privilegiar **separação de responsabilidades**, pois isso melhora manutenção, testes e evolução do código.
+
+---
+
+## 2) Arquitetura em camadas e por que ela foi escolhida
+
+A base foi organizada para evitar lógica de negócio espalhada em rotas/controladores e reduzir acoplamento com detalhes de infraestrutura.
+
+### Camadas
+
+- **`infra/server/routes`**: apenas definição de endpoints e composição de middlewares.
+- **`controllers`**: fronteira HTTP (parse de entrada, chamada de serviço, status code de saída).
+- **`service`**: regras de negócio (core da aplicação).
+- **`repository/interfaces`**: contratos de persistência (abstração).
+- **`repository/prisma`**: implementação real em banco.
+- **`repository/in-memory`**: implementação para testes unitários.
+- **`domain/dto` e `domain/model`**: contratos explícitos de entrada e saída.
+- **`libs`**: componentes transversais (Prisma, Redis, logger e Resend).
+
+### Decisão técnica
+
+Essa estrutura foi escolhida para garantir:
+
+1. **Testabilidade**: serviços são testados sem banco real usando repositórios in-memory.
+2. **Troca de infraestrutura com baixo impacto**: contratos protegem a camada de negócio.
+3. **Legibilidade**: cada pasta responde a um tipo de responsabilidade.
+4. **Evolução segura**: facilita adicionar módulos sem “efeito dominó”.
+
+---
+
+## 3) Tipagem e validação de dados
+
+### TypeScript em modo `strict`
+
+A tipagem forte reduz erro de integração entre camadas e dá previsibilidade em refatorações.
+
+### Zod nos DTOs
+
+As entradas são validadas no limite da aplicação (controller), antes de atingir regra de negócio.
+
+#### Motivos da escolha
+
+- validação declarativa e centralizada;
+- mensagens de erro consistentes;
+- suporte a transformação de payload (ex.: string de data para `Date`);
+- reduz risco de dados inválidos chegarem à camada de serviço.
+
+---
+
+## 4) Persistência e modelagem de domínio
+
+### PostgreSQL + Prisma
+
+Prisma foi escolhido por unir produtividade e segurança de tipos na camada de dados.
+
+### Decisões de modelagem
+
+- **`numeroPedido` autoincremental** em `Pedido`: melhora operação e comunicação com cliente.
+- **Relação `Pedido` ↔ `Carrinho` com `carrinhoId` único**: impede múltiplos pedidos para o mesmo carrinho finalizado.
+- **Separação `Item` e `ItemDescription`**: desacopla preço/variação de catálogo textual.
+- **Tabela de `tokenResets` dedicada**: isola ciclo de recuperação de senha com status e expiração.
+- **Campos de auditoria** (`createdAt`/`updatedAt`): essenciais para rastreio de mudanças.
+
+### Consistência transacional
+
+Em fluxos críticos (como criar pedido e finalizar carrinho), foi aplicada transação para preservar integridade de estado.
+
+---
+
+## 5) Segurança aplicada
+
+### Autenticação
+
+- Access token curto + refresh token longo.
+- Ambos em cookie `httpOnly`.
+
+**Motivo**: reduzir exposição de token ao JavaScript do cliente e equilibrar segurança com UX.
+
+### Autorização por perfil
+
+Controle explícito por papéis (`ADMIN` e `CLIENT`) via middleware dedicado.
+
+**Motivo**: separar autenticação (quem é) de autorização (o que pode fazer), deixando a política de acesso clara.
+
+### Hardening de API
+
+- `helmet` para headers de segurança;
+- `cors` parametrizado por ambiente;
+- `express.json` com limite de payload.
+
+---
+
+## 6) Resiliência e governança de erro
+
+Foi adotado um middleware global de erro com três trilhas:
+
+1. **Erro de validação** (Zod) com retorno orientado a campo;
+2. **Erro de persistência conhecido** (Prisma) traduzido para status HTTP adequado;
+3. **Erro inesperado** com resposta genérica e log estruturado.
+
+### Decisão técnica
+
+Padronizar erro protege o contrato da API e evita vazamento de detalhes internos para o cliente.
+
+---
+
+## 7) Observabilidade e diagnóstico
+
+### Stack de logs
+
+- **Pino + pino-http** para logs performáticos e estruturados.
+- **`requestId`** por requisição.
+- **`AsyncLocalStorage`** para transportar contexto no ciclo completo.
+- **Redaction** de campos sensíveis (senha/tokens/cookies).
+
+### Motivo da escolha
+
+Essa combinação melhora muito investigação de incidente, porque conecta logs de middleware, serviço e integração no mesmo contexto de request.
+
+### Observabilidade externa
+
+A stack opcional com **Alloy + Loki + Grafana** foi adicionada para centralização e consulta dos logs quando necessário.
+
+---
+
+## 8) Estratégia de proteção contra abuso
+
+### Rate limiting com Redis
+
+Rate limit foi implementado com store Redis para suportar execução em múltiplas instâncias.
+
+- política específica para autenticação;
+- política específica para recuperação de senha;
+- política global para demais chamadas.
+
+### Motivo da escolha
+
+Com Redis, os contadores não ficam presos à memória de um único processo, mantendo o controle eficaz em escala horizontal.
+
+---
+
+## 9) Integrações externas e desacoplamento
+
+### Serviço de frete
+
+O cálculo de distância foi encapsulado em `IDistanceProvider` com implementação concreta no provider externo.
+
+### Serviço de e-mail
+
+A entrega de e-mail usa `IEmailService` e implementação com Resend + templates centralizados.
+
+### Motivo da escolha
+
+Interfaces isolam o domínio das integrações externas e reduzem custo de troca de fornecedor no futuro.
+
+---
+
+## 10) Comunicação em tempo real
+
+Socket.IO foi adotado para atualizar status de pedidos em tempo real por sala de usuário.
+
+### Motivo da escolha
+
+Evita polling constante e melhora percepção de responsividade na experiência do cliente.
+
+---
+
+## 11) Testabilidade como decisão de arquitetura
+
+O projeto não trata teste como etapa final, mas como requisito de desenho.
+
+### Como isso aparece no código
+
+- serviços dependem de interfaces;
+- existem repositórios in-memory para testes unitários;
+- testes de integração cobrem fluxo HTTP com banco real;
+- CI valida lint, build e suíte de testes.
+
+### Motivo da escolha
+
+Essa estratégia reduz regressão em refatorações e acelera evolução com confiança.
+
+---
+
+## 12) Organização operacional do projeto
+
+### Estrutura de execução
+
+- desenvolvimento local com `ts-node-dev`;
+- build para `dist` com TypeScript;
+- Docker Compose para banco, Redis e stack opcional de observabilidade.
+
+### Banco e ciclo de schema
+
+- migrations versionadas em `prisma/migrations`;
+- seed para dados iniciais.
+
+### Motivo da escolha
+
+Padronizar o fluxo operacional reduz atrito de onboarding e divergência entre ambientes.
+
+---
+
+## 13) Stack adotada
+
 - Node.js
+- TypeScript
 - Express
 - Prisma
-- PostgreSql
-- JWT para autenticação
+- PostgreSQL
+- Redis
+- Zod
+- JWT
+- Pino
+- Socket.IO
+- Resend
+- Jest + Supertest
+- Docker Compose
 
-🧩 Funcionalidades principais
-Cadastro e autenticação de usuários
+---
 
-Criação e listagem de pedidos
+## 14) Repositórios relacionados
 
-Agendamento de pedidos
-
-Acesso administrativo para gerenciamento geral
-
-Proteção de rotas com autenticação JWT
-
-💡 Objetivo do projeto
-Este backend foi desenvolvido como parte de um sistema completo para negócios de alimentação, onde clientes podem fazer pedidos de forma simples, e o administrador pode visualizar e gerenciar esses pedidos por meio de um painel específico.
-
-🌐 Frontend
-A interface que consome esta API está disponível no repositório: <a href="https://github.com/Gabriell0610/Projeto_Encomenda_Pedido_Front">FrontEnd</a>
+Frontend oficial:  
+https://github.com/Gabriell0610/Projeto_Encomenda_Pedido_Front


### PR DESCRIPTION
### Motivation

- Provide a comprehensive, architecture-focused README for technical evaluation describing design decisions, trade-offs and operational guidance.
- Centralize rationale for choices (layered architecture, typing, integrations, security, observability and testability) to help reviewers and future contributors understand the codebase.

### Description

- Replaced the original short README with an expanded document that covers project objective, layered architecture, DTOs and Zod validation, database modeling with Prisma/Postgres, transaction decisions, and auditing fields.
- Added security and authorization details including cookie-based JWT strategy, role-based authorization, `helmet`/`cors` hardening and sensitive-field redaction in logs.
- Documented observability and resilience choices such as `pino` + `pino-http`, `AsyncLocalStorage` for request context, request id propagation, and an optional Alloy/Loki/Grafana stack; and rate-limiting with Redis for horizontal scaling.
- Included integration and abstraction details for external services (`IEmailService`, `IDistanceProvider`), Socket.IO real-time updates, testing strategy with in-memory repositories and integration tests, operational commands (`ts-node-dev`, build to `dist`, Docker Compose) and link to the frontend repo.

### Testing

- No automated tests were executed for this change because it is documentation-only and does not modify source code or tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da6647bf00832cb49782ca1c16af7b)