### PR TITLE
refactor(routes): convert manual middleware wrappers to Express middleware chaining

### DIFF
--- a/src/infra/server/routes/auth/auth.routes.ts
+++ b/src/infra/server/routes/auth/auth.routes.ts
@@ -3,7 +3,7 @@ import { Router } from "express";
 
 export const authRouter = Router();
 
-authRouter.post("/api/auth/register", (req, res, next) => {
+authRouter.post("/api/auth/register",
   /*
     #swagger.tags = ['Auth']
     #swagger.summary = 'Cadastra um novo usuário'
@@ -29,10 +29,10 @@ authRouter.post("/api/auth/register", (req, res, next) => {
     #swagger.responses[400] = { description: 'Dados inválidos' }
     #swagger.responses[409] = { description: 'E-mail já cadastrado' }
   */
-  authUserController.register(req, res, next);
-});
+  authUserController.register,
+);
 
-authRouter.post("/api/auth/login", (req, res, next) => {
+authRouter.post("/api/auth/login",
   /*
     #swagger.tags = ['Auth']
     #swagger.summary = 'Realiza login e retorna o accessToken'
@@ -54,10 +54,10 @@ authRouter.post("/api/auth/login", (req, res, next) => {
     #swagger.responses[200] = { description: 'Login realizado com sucesso' }
     #swagger.responses[401] = { description: 'Credenciais inválidas' }
   */
-  authUserController.login(req, res, next);
-});
+  authUserController.login,
+);
 
-authRouter.post("/api/auth/refresh", (req, res, next) => {
+authRouter.post("/api/auth/refresh",
   /*
     #swagger.tags = ['Auth']
     #swagger.summary = 'Renova o accessToken usando o refreshToken do cookie'
@@ -65,10 +65,10 @@ authRouter.post("/api/auth/refresh", (req, res, next) => {
     #swagger.responses[200] = { description: 'Token renovado com sucesso' }
     #swagger.responses[401] = { description: 'Refresh token inválido ou expirado' }
   */
-  authUserController.refreshToken(req, res, next);
-});
+  authUserController.refreshToken,
+);
 
-authRouter.post("/api/auth/logout", (req, res, next) => {
+authRouter.post("/api/auth/logout",
   /*
     #swagger.tags = ['Auth']
     #swagger.summary = 'Realiza logout e invalida o refreshToken'
@@ -76,10 +76,10 @@ authRouter.post("/api/auth/logout", (req, res, next) => {
     #swagger.responses[204] = { description: 'Logout realizado com sucesso' }
     #swagger.responses[401] = { description: 'Não autorizado' }
   */
-  authUserController.logout(req, res, next);
-});
+  authUserController.logout,
+);
 
-authRouter.post("/api/auth/forgot-password", (req, res, next) => {
+authRouter.post("/api/auth/forgot-password",
   /*
     #swagger.tags = ['Auth']
     #swagger.summary = 'Envia e-mail de recuperação de senha'
@@ -100,10 +100,10 @@ authRouter.post("/api/auth/forgot-password", (req, res, next) => {
     #swagger.responses[200] = { description: 'E-mail enviado com sucesso' }
     #swagger.responses[404] = { description: 'Usuário não encontrado' }
   */
-  authUserController.forgetPassword(req, res, next);
-});
+  authUserController.forgetPassword,
+);
 
-authRouter.post("/api/auth/validate-token", (req, res, next) => {
+authRouter.post("/api/auth/validate-token",
   /*
     #swagger.tags = ['Auth']
     #swagger.summary = 'Valida o token de recuperação de senha'
@@ -125,10 +125,10 @@ authRouter.post("/api/auth/validate-token", (req, res, next) => {
     #swagger.responses[200] = { description: 'Token válido' }
     #swagger.responses[400] = { description: 'Token inválido ou expirado' }
   */
-  authUserController.validateToken(req, res, next);
-});
+  authUserController.validateToken,
+);
 
-authRouter.post("/api/auth/reset-password", (req, res, next) => {
+authRouter.post("/api/auth/reset-password",
   /*
     #swagger.tags = ['Auth']
     #swagger.summary = 'Redefine a senha do usuário'
@@ -151,5 +151,5 @@ authRouter.post("/api/auth/reset-password", (req, res, next) => {
     #swagger.responses[200] = { description: 'Senha redefinida com sucesso' }
     #swagger.responses[400] = { description: 'Token inválido ou expirado' }
   */
-  authUserController.resetPassword(req, res, next);
-});
+  authUserController.resetPassword,
+);

--- a/src/infra/server/routes/cart/cart.routes.ts
+++ b/src/infra/server/routes/cart/cart.routes.ts
@@ -5,7 +5,7 @@ import { Router } from "express";
 
 const cartRouter = Router();
 
-cartRouter.post("/api/cart", (req, res, next) => {
+cartRouter.post("/api/cart",
   /*
     #swagger.tags = ['Cart']
     #swagger.summary = 'Adiciona um item ao carrinho'
@@ -30,12 +30,12 @@ cartRouter.post("/api/cart", (req, res, next) => {
     #swagger.responses[400] = { description: 'Dados inválidos' }
     #swagger.responses[401] = { description: 'Não autorizado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization.anyRole().authorize(req, res, () => cartController.createCart(req, res, next)),
-  );
-});
+  jwtAtuhenticator.authenticate,
+  authorization.anyRole().authorize,
+  cartController.createCart,
+);
 
-cartRouter.get("/api/cart", (req, res, next) => {
+cartRouter.get("/api/cart",
   /*
     #swagger.tags = ['Cart']
     #swagger.summary = 'Lista o carrinho do usuário logado'
@@ -43,12 +43,12 @@ cartRouter.get("/api/cart", (req, res, next) => {
     #swagger.responses[200] = { description: 'Carrinho retornado com sucesso' }
     #swagger.responses[401] = { description: 'Não autorizado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization.anyRole().authorize(req, res, () => cartController.listCart(req, res, next)),
-  );
-});
+  jwtAtuhenticator.authenticate,
+  authorization.anyRole().authorize,
+  cartController.listCart,
+);
 
-cartRouter.patch("/api/cart/item/:itemId/increment", (req, res, next) => {
+cartRouter.patch("/api/cart/item/:itemId/increment",
   /*
     #swagger.tags = ['Cart']
     #swagger.summary = 'Incrementa a quantidade de um item no carrinho'
@@ -63,12 +63,12 @@ cartRouter.patch("/api/cart/item/:itemId/increment", (req, res, next) => {
     #swagger.responses[200] = { description: 'Quantidade incrementada com sucesso' }
     #swagger.responses[404] = { description: 'Item não encontrado no carrinho' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization.anyRole().authorize(req, res, () => cartController.incremetItemQuantity(req, res, next)),
-  );
-});
+  jwtAtuhenticator.authenticate,
+  authorization.anyRole().authorize,
+  cartController.incremetItemQuantity,
+);
 
-cartRouter.patch("/api/cart/item/:itemId/decrement", (req, res, next) => {
+cartRouter.patch("/api/cart/item/:itemId/decrement",
   /*
     #swagger.tags = ['Cart']
     #swagger.summary = 'Decrementa a quantidade de um item no carrinho'
@@ -83,12 +83,12 @@ cartRouter.patch("/api/cart/item/:itemId/decrement", (req, res, next) => {
     #swagger.responses[200] = { description: 'Quantidade decrementada com sucesso' }
     #swagger.responses[404] = { description: 'Item não encontrado no carrinho' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization.anyRole().authorize(req, res, () => cartController.decrementItemQuantity(req, res, next)),
-  );
-});
+  jwtAtuhenticator.authenticate,
+  authorization.anyRole().authorize,
+  cartController.decrementItemQuantity,
+);
 
-cartRouter.delete("/api/cart/item/:itemId", (req, res, next) => {
+cartRouter.delete("/api/cart/item/:itemId",
   /*
     #swagger.tags = ['Cart']
     #swagger.summary = 'Remove um item do carrinho'
@@ -103,9 +103,9 @@ cartRouter.delete("/api/cart/item/:itemId", (req, res, next) => {
     #swagger.responses[204] = { description: 'Item removido do carrinho com sucesso' }
     #swagger.responses[404] = { description: 'Item não encontrado no carrinho' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization.anyRole().authorize(req, res, () => cartController.removeItemCart(req, res, next)),
-  );
-});
+  jwtAtuhenticator.authenticate,
+  authorization.anyRole().authorize,
+  cartController.removeItemCart,
+);
 
 export { cartRouter };

--- a/src/infra/server/routes/dashboard/dashboard.route.ts
+++ b/src/infra/server/routes/dashboard/dashboard.route.ts
@@ -6,7 +6,7 @@ import { Router } from "express";
 
 export const dashboardRouter = Router();
 
-dashboardRouter.get("/api/dashboard/summary", (req, res, next) => {
+dashboardRouter.get("/api/dashboard/summary",
   /*
     #swagger.tags = ['Dashboard']
     #swagger.summary = 'Retorna o resumo do dashboard (admin)'
@@ -27,14 +27,14 @@ dashboardRouter.get("/api/dashboard/summary", (req, res, next) => {
     #swagger.responses[401] = { description: 'Não autorizado' }
     #swagger.responses[403] = { description: 'Sem permissão' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization
+  jwtAtuhenticator.authenticate,
+  authorization
       .ofRoles([AccessProfile.ADMIN])
-      .authorize(req, res, () => dashboardController.getDashboardSummary(req, res, next)),
-  );
-});
+      .authorize,
+  dashboardController.getDashboardSummary,
+);
 
-dashboardRouter.get("/api/dashboard/revenue", (req, res, next) => {
+dashboardRouter.get("/api/dashboard/revenue",
   /*
     #swagger.tags = ['Dashboard']
     #swagger.summary = 'Retorna o faturamento do dashboard (admin)'
@@ -55,14 +55,14 @@ dashboardRouter.get("/api/dashboard/revenue", (req, res, next) => {
     #swagger.responses[401] = { description: 'Não autorizado' }
     #swagger.responses[403] = { description: 'Sem permissão' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization
+  jwtAtuhenticator.authenticate,
+  authorization
       .ofRoles([AccessProfile.ADMIN])
-      .authorize(req, res, () => dashboardController.getDashboardRevenue(req, res, next)),
-  );
-});
+      .authorize,
+  dashboardController.getDashboardRevenue,
+);
 
-dashboardRouter.get("/api/dashboard/quick-stats", (req, res, next) => {
+dashboardRouter.get("/api/dashboard/quick-stats",
   /*
     #swagger.tags = ['Dashboard']
     #swagger.summary = 'Retorna estatísticas rápidas do dashboard (admin)'
@@ -71,9 +71,9 @@ dashboardRouter.get("/api/dashboard/quick-stats", (req, res, next) => {
     #swagger.responses[401] = { description: 'Não autorizado' }
     #swagger.responses[403] = { description: 'Sem permissão' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization
+  jwtAtuhenticator.authenticate,
+  authorization
       .ofRoles([AccessProfile.ADMIN])
-      .authorize(req, res, () => dashboardController.getDashboardQuickSats(req, res, next)),
-  );
-});
+      .authorize,
+  dashboardController.getDashboardQuickSats,
+);

--- a/src/infra/server/routes/itens/itens.routes.ts
+++ b/src/infra/server/routes/itens/itens.routes.ts
@@ -6,7 +6,7 @@ import { Router } from "express";
 
 const itensRouter = Router();
 
-itensRouter.post("/api/itens", (req, res, next) => {
+itensRouter.post("/api/itens",
   /*
     #swagger.tags = ['Itens']
     #swagger.summary = 'Cria um novo item (admin)'
@@ -38,24 +38,24 @@ itensRouter.post("/api/itens", (req, res, next) => {
     #swagger.responses[401] = { description: 'Não autorizado' }
     #swagger.responses[403] = { description: 'Sem permissão' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization.ofRoles([AccessProfile.ADMIN]).authorize(req, res, () => itensController.create(req, res, next)),
-  );
-});
+  jwtAtuhenticator.authenticate,
+  authorization.ofRoles([AccessProfile.ADMIN]).authorize,
+  itensController.create,
+);
 
-itensRouter.get("/api/itens", (req, res, next) => {
+itensRouter.get("/api/itens",
   /*
     #swagger.tags = ['Itens']
     #swagger.summary = 'Lista todos os itens'
     #swagger.security = [{ "bearerAuth": [] }]
     #swagger.responses[200] = { description: 'Lista de itens retornada com sucesso' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization.anyRole().authorize(req, res, () => itensController.list(req, res, next)),
-  );
-});
+  jwtAtuhenticator.authenticate,
+  authorization.anyRole().authorize,
+  itensController.list,
+);
 
-itensRouter.get("/api/itens/:id", (req, res, next) => {
+itensRouter.get("/api/itens/:id",
   /*
     #swagger.tags = ['Itens']
     #swagger.summary = 'Busca um item pelo ID'
@@ -70,12 +70,12 @@ itensRouter.get("/api/itens/:id", (req, res, next) => {
     #swagger.responses[200] = { description: 'Item encontrado' }
     #swagger.responses[404] = { description: 'Item não encontrado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization.anyRole().authorize(req, res, () => itensController.listItemById(req, res, next)),
-  );
-});
+  jwtAtuhenticator.authenticate,
+  authorization.anyRole().authorize,
+  itensController.listItemById,
+);
 
-itensRouter.put("/api/itens/:id", (req, res, next) => {
+itensRouter.put("/api/itens/:id",
   /*
     #swagger.tags = ['Itens']
     #swagger.summary = 'Atualiza um item (admin)'
@@ -111,12 +111,12 @@ itensRouter.put("/api/itens/:id", (req, res, next) => {
     #swagger.responses[200] = { description: 'Item atualizado com sucesso' }
     #swagger.responses[404] = { description: 'Item não encontrado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization.ofRoles([AccessProfile.ADMIN]).authorize(req, res, () => itensController.update(req, res, next)),
-  );
-});
+  jwtAtuhenticator.authenticate,
+  authorization.ofRoles([AccessProfile.ADMIN]).authorize,
+  itensController.update,
+);
 
-itensRouter.patch("/api/itens/:id", (req, res, next) => {
+itensRouter.patch("/api/itens/:id",
   /*
     #swagger.tags = ['Itens']
     #swagger.summary = 'Inativa Item'
@@ -131,11 +131,11 @@ itensRouter.patch("/api/itens/:id", (req, res, next) => {
     #swagger.responses[200] = { description: 'Item inativado com sucesso' }
     #swagger.responses[404] = { description: 'Item não encontrado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization
+  jwtAtuhenticator.authenticate,
+  authorization
       .ofRoles([AccessProfile.ADMIN])
-      .authorize(req, res, () => itensController.inactiveItem(req, res, next)),
-  );
-});
+      .authorize,
+  itensController.inactiveItem,
+);
 
 export { itensRouter };

--- a/src/infra/server/routes/order/order.routes.ts
+++ b/src/infra/server/routes/order/order.routes.ts
@@ -6,7 +6,7 @@ import { Router } from "express";
 
 export const orderRouter = Router();
 
-orderRouter.post("/api/order", (req, res, next) => {
+orderRouter.post("/api/order",
   /*
     #swagger.tags = ['Orders']
     #swagger.summary = 'Cria um novo pedido'
@@ -16,12 +16,12 @@ orderRouter.post("/api/order", (req, res, next) => {
     #swagger.responses[400] = { description: 'Dados inválidos' }
     #swagger.responses[401] = { description: 'Não autorizado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization.anyRole().authorize(req, res, () => orderController.create(req, res, next)),
-  );
-});
+  jwtAtuhenticator.authenticate,
+  authorization.anyRole().authorize,
+  orderController.create,
+);
 
-orderRouter.get("/api/order", (req, res, next) => {
+orderRouter.get("/api/order",
   /*
     #swagger.tags = ['Orders']
     #swagger.summary = 'Lista todos os pedidos (admin)'
@@ -36,14 +36,14 @@ orderRouter.get("/api/order", (req, res, next) => {
     #swagger.responses[401] = { description: 'Não autorizado' }
     #swagger.responses[403] = { description: 'Sem permissão' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization
+  jwtAtuhenticator.authenticate,
+  authorization
       .ofRoles([AccessProfile.ADMIN])
-      .authorize(req, res, () => orderController.listAllOrders(req, res, next)),
-  );
-});
+      .authorize,
+  orderController.listAllOrders,
+);
 
-orderRouter.get("/api/order/me", (req, res, next) => {
+orderRouter.get("/api/order/me",
   /*
     #swagger.tags = ['Orders']
     #swagger.summary = 'Lista os pedidos do usuário logado'
@@ -51,14 +51,14 @@ orderRouter.get("/api/order/me", (req, res, next) => {
     #swagger.responses[200] = { description: 'Pedidos do usuário listados com sucesso' }
     #swagger.responses[401] = { description: 'Não autorizado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization
+  jwtAtuhenticator.authenticate,
+  authorization
       .ofRoles([AccessProfile.CLIENT, AccessProfile.ADMIN])
-      .authorize(req, res, () => orderController.listOrdersMe(req, res, next)),
-  );
-});
+      .authorize,
+  orderController.listOrdersMe,
+);
 
-orderRouter.get("/api/order/:id", (req, res, next) => {
+orderRouter.get("/api/order/:id",
   /*
     #swagger.tags = ['Orders']
     #swagger.summary = 'Busca um pedido pelo ID'
@@ -73,12 +73,12 @@ orderRouter.get("/api/order/:id", (req, res, next) => {
     #swagger.responses[200] = { description: 'Pedido encontrado com sucesso' }
     #swagger.responses[404] = { description: 'Pedido não encontrado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization.anyRole().authorize(req, res, () => orderController.listOrderById(req, res, next)),
-  );
-});
+  jwtAtuhenticator.authenticate,
+  authorization.anyRole().authorize,
+  orderController.listOrderById,
+);
 
-orderRouter.put("/api/order/:id", (req, res, next) => {
+orderRouter.put("/api/order/:id",
   /*
     #swagger.tags = ['Orders']
     #swagger.summary = 'Atualiza um pedido (cliente ou admin)'
@@ -95,14 +95,14 @@ orderRouter.put("/api/order/:id", (req, res, next) => {
     #swagger.responses[400] = { description: 'Dados inválidos' }
     #swagger.responses[404] = { description: 'Pedido não encontrado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization
+  jwtAtuhenticator.authenticate,
+  authorization
       .ofRoles([AccessProfile.CLIENT, AccessProfile.ADMIN])
-      .authorize(req, res, () => orderController.update(req, res, next)),
-  );
-});
+      .authorize,
+  orderController.update,
+);
 
-orderRouter.put("/api/order/admin/:id", (req, res, next) => {
+orderRouter.put("/api/order/admin/:id",
   /*
     #swagger.tags = ['Orders']
     #swagger.summary = 'Atualiza um pedido como admin'
@@ -118,14 +118,14 @@ orderRouter.put("/api/order/admin/:id", (req, res, next) => {
     #swagger.responses[200] = { description: 'Pedido atualizado com sucesso' }
     #swagger.responses[404] = { description: 'Pedido não encontrado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization
+  jwtAtuhenticator.authenticate,
+  authorization
       .ofRoles([AccessProfile.ADMIN])
-      .authorize(req, res, () => orderController.adminUpdateOrder(req, res, next)),
-  );
-});
+      .authorize,
+  orderController.adminUpdateOrder,
+);
 
-orderRouter.patch("/api/order/cancel/:id", (req, res, next) => {
+orderRouter.patch("/api/order/cancel/:id",
   /*
     #swagger.tags = ['Orders']
     #swagger.summary = 'Cancela um pedido'
@@ -140,12 +140,12 @@ orderRouter.patch("/api/order/cancel/:id", (req, res, next) => {
     #swagger.responses[200] = { description: 'Pedido cancelado com sucesso' }
     #swagger.responses[404] = { description: 'Pedido não encontrado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization.anyRole().authorize(req, res, () => orderController.cancelOrder(req, res, next)),
-  );
-});
+  jwtAtuhenticator.authenticate,
+  authorization.anyRole().authorize,
+  orderController.cancelOrder,
+);
 
-orderRouter.patch("/api/order/confirm/:id", (req, res, next) => {
+orderRouter.patch("/api/order/confirm/:id",
   /*
     #swagger.tags = ['Orders']
     #swagger.summary = 'Confirma um pedido (cliente)'
@@ -161,14 +161,14 @@ orderRouter.patch("/api/order/confirm/:id", (req, res, next) => {
     #swagger.responses[403] = { description: 'Sem permissão' }
     #swagger.responses[404] = { description: 'Pedido não encontrado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization
+  jwtAtuhenticator.authenticate,
+  authorization
       .ofRoles([AccessProfile.CLIENT])
-      .authorize(req, res, () => orderController.clientConfirmOrder(req, res, next)),
-  );
-});
+      .authorize,
+  orderController.clientConfirmOrder,
+);
 
-orderRouter.patch("/api/changeStatus/order/:id", (req, res, next) => {
+orderRouter.patch("/api/changeStatus/order/:id",
   /*
     #swagger.tags = ['Orders']
     #swagger.summary = 'Altera o status de um pedido (admin)'
@@ -185,9 +185,9 @@ orderRouter.patch("/api/changeStatus/order/:id", (req, res, next) => {
     #swagger.responses[400] = { description: 'Status inválido' }
     #swagger.responses[404] = { description: 'Pedido não encontrado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization
+  jwtAtuhenticator.authenticate,
+  authorization
       .ofRoles([AccessProfile.ADMIN])
-      .authorize(req, res, () => orderController.changeStatusOrder(req, res, next)),
-  );
-});
+      .authorize,
+  orderController.changeStatusOrder,
+);

--- a/src/infra/server/routes/paymentMethods/route.ts
+++ b/src/infra/server/routes/paymentMethods/route.ts
@@ -5,7 +5,7 @@ import { Router } from "express";
 
 export const paymentMethodRouter = Router();
 
-paymentMethodRouter.get("/api/paymentMethods", (req, res, next) => {
+paymentMethodRouter.get("/api/paymentMethods",
   /*
     #swagger.tags = ['Payment Methods']
     #swagger.summary = 'Lista todos os métodos de pagamento disponíveis'
@@ -13,7 +13,7 @@ paymentMethodRouter.get("/api/paymentMethods", (req, res, next) => {
     #swagger.responses[200] = { description: 'Métodos de pagamento listados com sucesso' }
     #swagger.responses[401] = { description: 'Não autorizado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization.anyRole().authorize(req, res, () => paymentMethodController.listAllPaymentMethod(req, res, next)),
-  );
-});
+  jwtAtuhenticator.authenticate,
+  authorization.anyRole().authorize,
+  paymentMethodController.listAllPaymentMethod,
+);

--- a/src/infra/server/routes/shipping/route.ts
+++ b/src/infra/server/routes/shipping/route.ts
@@ -5,7 +5,7 @@ import { Router } from "express";
 
 export const shippingRouter = Router();
 
-shippingRouter.post("/api/shipping", (req, res, next) => {
+shippingRouter.post("/api/shipping",
   /*
     #swagger.tags = ['Shipping']
     #swagger.summary = 'Calcula o frete para o endereço do usuário'
@@ -16,7 +16,7 @@ shippingRouter.post("/api/shipping", (req, res, next) => {
     #swagger.responses[401] = { description: 'Não autorizado' }
     #swagger.responses[404] = { description: 'Endereço não encontrado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization.anyRole().authorize(req, res, () => shippingController.calculateShipping(req, res, next)),
-  );
-});
+  jwtAtuhenticator.authenticate,
+  authorization.anyRole().authorize,
+  shippingController.calculateShipping,
+);

--- a/src/infra/server/routes/user/user.routes.ts
+++ b/src/infra/server/routes/user/user.routes.ts
@@ -6,7 +6,7 @@ import { Router } from "express";
 
 const userRouter = Router();
 
-userRouter.get("/api/users", (req, res, next) => {
+userRouter.get("/api/users",
   /*
     #swagger.tags = ['Users']
     #swagger.summary = 'Lista todos os usuários (admin)'
@@ -15,12 +15,12 @@ userRouter.get("/api/users", (req, res, next) => {
     #swagger.responses[401] = { description: 'Não autorizado' }
     #swagger.responses[403] = { description: 'Sem permissão' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization.ofRoles([AccessProfile.ADMIN]).authorize(req, res, () => userController.list(req, res, next)),
-  );
-});
+  jwtAtuhenticator.authenticate,
+  authorization.ofRoles([AccessProfile.ADMIN]).authorize,
+  userController.list,
+);
 
-userRouter.get("/api/users/me", (req, res, next) => {
+userRouter.get("/api/users/me",
   /*
     #swagger.tags = ['Users']
     #swagger.summary = 'Retorna os dados do usuário logado'
@@ -28,14 +28,14 @@ userRouter.get("/api/users/me", (req, res, next) => {
     #swagger.responses[200] = { description: 'Dados do usuário logado' }
     #swagger.responses[401] = { description: 'Não autorizado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization
+  jwtAtuhenticator.authenticate,
+  authorization
       .ofRoles([AccessProfile.CLIENT, AccessProfile.ADMIN])
-      .authorize(req, res, () => userController.listLoggedUser(req, res, next)),
-  );
-});
+      .authorize,
+  userController.listLoggedUser,
+);
 
-userRouter.put("/api/users", (req, res, next) => {
+userRouter.put("/api/users",
   /*
     #swagger.tags = ['Users']
     #swagger.summary = 'Atualiza os dados do usuário logado'
@@ -59,14 +59,14 @@ userRouter.put("/api/users", (req, res, next) => {
     #swagger.responses[400] = { description: 'Dados inválidos' }
     #swagger.responses[401] = { description: 'Não autorizado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization
+  jwtAtuhenticator.authenticate,
+  authorization
       .ofRoles([AccessProfile.CLIENT, AccessProfile.ADMIN])
-      .authorize(req, res, () => userController.updateUser(req, res, next)),
-  );
-});
+      .authorize,
+  userController.updateUser,
+);
 
-userRouter.post("/api/users/address", (req, res, next) => {
+userRouter.post("/api/users/address",
   /*
     #swagger.tags = ['Users - Address']
     #swagger.summary = 'Adiciona um endereço ao usuário logado'
@@ -95,14 +95,14 @@ userRouter.post("/api/users/address", (req, res, next) => {
     #swagger.responses[400] = { description: 'Dados inválidos' }
     #swagger.responses[401] = { description: 'Não autorizado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization
+  jwtAtuhenticator.authenticate,
+  authorization
       .ofRoles([AccessProfile.CLIENT, AccessProfile.ADMIN])
-      .authorize(req, res, () => userController.addAddress(req, res, next)),
-  );
-});
+      .authorize,
+  userController.addAddress,
+);
 
-userRouter.get("/api/users/address/me", (req, res, next) => {
+userRouter.get("/api/users/address/me",
   /*
     #swagger.tags = ['Users - Address']
     #swagger.summary = 'Lista os endereços do usuário logado'
@@ -110,14 +110,14 @@ userRouter.get("/api/users/address/me", (req, res, next) => {
     #swagger.responses[200] = { description: 'Lista de endereços retornada com sucesso' }
     #swagger.responses[401] = { description: 'Não autorizado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization
+  jwtAtuhenticator.authenticate,
+  authorization
       .ofRoles([AccessProfile.CLIENT, AccessProfile.ADMIN])
-      .authorize(req, res, () => userController.listAddressByUserId(req, res, next)),
-  );
-});
+      .authorize,
+  userController.listAddressByUserId,
+);
 
-userRouter.put("/api/users/address/:idAddress", (req, res, next) => {
+userRouter.put("/api/users/address/:idAddress",
   /*
     #swagger.tags = ['Users - Address']
     #swagger.summary = 'Atualiza um endereço do usuário logado'
@@ -151,14 +151,14 @@ userRouter.put("/api/users/address/:idAddress", (req, res, next) => {
     #swagger.responses[200] = { description: 'Endereço atualizado com sucesso' }
     #swagger.responses[404] = { description: 'Endereço não encontrado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization
+  jwtAtuhenticator.authenticate,
+  authorization
       .ofRoles([AccessProfile.CLIENT, AccessProfile.ADMIN])
-      .authorize(req, res, () => userController.updateUserAddress(req, res, next)),
-  );
-});
+      .authorize,
+  userController.updateUserAddress,
+);
 
-userRouter.delete("/api/users/:idAddress/address", (req, res, next) => {
+userRouter.delete("/api/users/:idAddress/address",
   /*
     #swagger.tags = ['Users - Address']
     #swagger.summary = 'Remove um endereço do usuário logado'
@@ -173,11 +173,11 @@ userRouter.delete("/api/users/:idAddress/address", (req, res, next) => {
     #swagger.responses[204] = { description: 'Endereço removido com sucesso' }
     #swagger.responses[404] = { description: 'Endereço não encontrado' }
   */
-  jwtAtuhenticator.authenticate(req, res, () =>
-    authorization
+  jwtAtuhenticator.authenticate,
+  authorization
       .ofRoles([AccessProfile.CLIENT, AccessProfile.ADMIN])
-      .authorize(req, res, () => userController.removeAddress(req, res, next)),
-  );
-});
+      .authorize,
+  userController.removeAddress,
+);
 
 export { userRouter };


### PR DESCRIPTION
### Motivation
- Existing route files used wrapper functions that manually invoked middleware and controllers, which breaks Express error flow and prevents `next(error)` from stopping execution properly.
- Converting to the standard middleware chaining pattern ensures correct error handling and proper 401/403 responses without changing business logic.

### Description
- Replaced all `(req, res, next) => { ... }` route wrappers with direct Express middleware chaining in route files, keeping the route path, middleware order, controller references, and Swagger comments unchanged.
- Updated files: `src/infra/server/routes/auth/auth.routes.ts`, `src/infra/server/routes/cart/cart.routes.ts`, `src/infra/server/routes/dashboard/dashboard.route.ts`, `src/infra/server/routes/itens/itens.routes.ts`, `src/infra/server/routes/order/order.routes.ts`, `src/infra/server/routes/paymentMethods/route.ts`, `src/infra/server/routes/shipping/route.ts`, and `src/infra/server/routes/user/user.routes.ts`.
- Preserved all `/* #swagger.* */` blocks immediately after the route path and retained TypeScript-compatible signatures and imports.
- Only the route declaration structure was changed; no middleware implementations, controller logic, imports, or variable names were modified.

### Testing
- Ran a pre-refactor search `rg "\(req, res, next\) =>|authenticate\(req, res|authorize\(req, res" -n src` to locate all manual wrapper usages and confirm the scope of changes, which returned the expected matches before refactor.
- Ran a post-refactor search `rg "\(req, res, next\) =>|authenticate\(req, res|authorize\(req, res" -n src/infra/server/routes` which returned no matches, confirming the manual invocation pattern was removed from all route files (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f686b22e54832cac2f0d408b6073ae)