### PR TITLE
Replace `TypeItem` enum with `ItemType` model and update migrations, seeds, and API

### DIFF
--- a/prisma/migrations/20260515120000_replace_type_item_with_item_type/migration.sql
+++ b/prisma/migrations/20260515120000_replace_type_item_with_item_type/migration.sql
@@ -1,0 +1,48 @@
+-- CreateTable
+CREATE TABLE "item_types" (
+    "id" TEXT NOT NULL,
+    "nome" TEXT NOT NULL,
+    "createdAt" TIMESTAMPTZ(3) DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3),
+
+    CONSTRAINT "item_types_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "item_types_nome_key" ON "item_types"("nome");
+
+-- AlterTable
+ALTER TABLE "ItemDescription" ADD COLUMN "itemTypeId" TEXT;
+
+-- Preserve old enum values as dynamic item types.
+INSERT INTO "item_types" ("id", "nome", "createdAt", "updatedAt")
+SELECT DISTINCT
+    LOWER(
+      CONCAT(
+        SUBSTRING(MD5("tipo"::TEXT) FROM 1 FOR 8), '-',
+        SUBSTRING(MD5("tipo"::TEXT) FROM 9 FOR 4), '-',
+        SUBSTRING(MD5("tipo"::TEXT) FROM 13 FOR 4), '-',
+        SUBSTRING(MD5("tipo"::TEXT) FROM 17 FOR 4), '-',
+        SUBSTRING(MD5("tipo"::TEXT) FROM 21 FOR 12)
+      )
+    ) AS "id",
+    "tipo"::TEXT AS "nome",
+    CURRENT_TIMESTAMP AS "createdAt",
+    CURRENT_TIMESTAMP AS "updatedAt"
+FROM "ItemDescription"
+WHERE "tipo" IS NOT NULL
+ON CONFLICT ("nome") DO NOTHING;
+
+-- Relate existing item descriptions to their new dynamic item types.
+UPDATE "ItemDescription" AS description
+SET "itemTypeId" = type."id"
+FROM "item_types" AS type
+WHERE description."tipo" IS NOT NULL
+  AND type."nome" = description."tipo"::TEXT;
+
+-- Drop old enum column and enum type.
+ALTER TABLE "ItemDescription" DROP COLUMN "tipo";
+DROP TYPE IF EXISTS "TypeItem";
+
+-- AddForeignKey
+ALTER TABLE "ItemDescription" ADD CONSTRAINT "ItemDescription_itemTypeId_fkey" FOREIGN KEY ("itemTypeId") REFERENCES "item_types"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,14 +50,6 @@ enum UnityItem {
   UMA_DUZIA
 }
 
-enum TypeItem {
-  EMPADAO
-  PANQUECA
-  ALMONDEGA
-  LASANHA
-  ESCONDIDINHO
-}
-
 model Usuario {
   id          String            @id @default(uuid())
   nome        String            @db.VarChar()
@@ -170,11 +162,23 @@ model ItemDescription {
   descricao  String      @db.VarChar()
   image      String      @db.VarChar()
   nome       String      @db.VarChar()
-  tipo       TypeItem?
+  itemTypeId String?
+  itemType   ItemType?   @relation(fields: [itemTypeId], references: [id])
   createdAt  DateTime?   @default(now()) @db.Timestamptz(3)
   updatedAt  DateTime?   @updatedAt @db.Timestamptz(3)
   disponivel StatusItem?
   item       Item[]
+}
+
+model ItemType {
+  id        String    @id @default(uuid())
+  nome      String    @unique
+  createdAt DateTime? @default(now()) @db.Timestamptz(3)
+  updatedAt DateTime? @updatedAt @db.Timestamptz(3)
+
+  itemDescriptions ItemDescription[]
+
+  @@map("item_types")
 }
 
 model CarrinhoItens {

--- a/prisma/seed/item.ts
+++ b/prisma/seed/item.ts
@@ -1,5 +1,5 @@
 import { prisma } from "../../src/libs/prisma";
-import { ItemSize, StatusItem, TypeItem } from "@prisma/client";
+import { ItemSize, StatusItem } from "@prisma/client";
 
 const itemDescriptionDto = [
   {
@@ -12,7 +12,7 @@ const itemDescriptionDto = [
       { preco: 50.0, unidades: null, tamanho: "G", precoUnitario: null },
       { preco: 60.0, unidades: null, tamanho: "GG", precoUnitario: null },
     ],
-    tipoItem: TypeItem.EMPADAO,
+    tipoItem: "EMPADAO",
   },
   {
     nome: "Empadão de Calabresa",
@@ -24,7 +24,7 @@ const itemDescriptionDto = [
       { preco: 50.0, unidades: null, tamanho: "G", precoUnitario: null },
       { preco: 60.0, unidades: null, tamanho: "GG", precoUnitario: null },
     ],
-    tipoItem: TypeItem.EMPADAO,
+    tipoItem: "EMPADAO",
   },
   {
     nome: "Empadão de Palmito",
@@ -36,7 +36,7 @@ const itemDescriptionDto = [
       { preco: 65.0, unidades: null, tamanho: "G", precoUnitario: null },
       { preco: 85.0, unidades: null, tamanho: "GG", precoUnitario: null },
     ],
-    tipoItem: TypeItem.EMPADAO,
+    tipoItem: "EMPADAO",
   },
   {
     nome: "Empadão de Camarão",
@@ -48,35 +48,35 @@ const itemDescriptionDto = [
       { preco: 73.0, unidades: null, tamanho: "G", precoUnitario: null },
       { preco: 90.0, unidades: null, tamanho: "GG", precoUnitario: null },
     ],
-    tipoItem: TypeItem.EMPADAO,
+    tipoItem: "EMPADAO",
   },
   {
     nome: "Panqueca de Carne Moída",
     descricao: "Carne moída ao molho caseiro recheando panquecas macias e saborosas!",
     image: "",
     itens: [{ precoUnitario: 6.67, unidades: 6, tamanho: null, preco: 40.02 }],
-    tipoItem: TypeItem.PANQUECA,
+    tipoItem: "PANQUECA",
   },
   {
     nome: "Panqueca de Frango",
     descricao: "Frango desfiado e temperado em panquecas leves feitas na hora!",
     image: "",
     itens: [{ precoUnitario: 6.67, unidades: 6, tamanho: null, preco: 40.02 }],
-    tipoItem: TypeItem.PANQUECA,
+    tipoItem: "PANQUECA",
   },
   {
     nome: "Panqueca de Queijo e Presunto",
     descricao: "Queijo derretido e presunto fatiado em panqueca macia e gratinada",
     image: "",
     itens: [{ precoUnitario: 6.67, unidades: 6, tamanho: null, preco: 40.0 }],
-    tipoItem: TypeItem.PANQUECA,
+    tipoItem: "PANQUECA",
   },
   {
     nome: "Almôndega De Carne",
     descricao: "Almôndegas artesanais de carne moída ao molho encorpado e aromático!",
     image: "",
     itens: [{ precoUnitario: 3.4, unidades: 12, tamanho: null, preco: 40.0 }],
-    tipoItem: TypeItem.ALMONDEGA,
+    tipoItem: "ALMONDEGA",
   },
 ];
 
@@ -91,7 +91,12 @@ const seedItens = async () => {
           descricao: desc.descricao,
           nome: desc.nome,
           image: desc.image,
-          tipo: desc.tipoItem,
+          itemType: {
+            connectOrCreate: {
+              where: { nome: desc.tipoItem },
+              create: { nome: desc.tipoItem },
+            },
+          },
           disponivel: StatusItem.ATIVO,
           createdAt: new Date(),
           updatedAt: new Date(),

--- a/prisma/seed/itemType.ts
+++ b/prisma/seed/itemType.ts
@@ -1,0 +1,19 @@
+import { prisma } from "../../src/libs/prisma";
+
+const itemTypes = ["EMPADAO", "PANQUECA", "ALMONDEGA", "LASANHA", "ESCONDIDINHO"];
+
+export const seedItemTypes = async () => {
+  try {
+    for (const nome of itemTypes) {
+      await prisma.itemType.upsert({
+        where: { nome },
+        update: {},
+        create: { nome },
+      });
+    }
+
+    console.log("Tipos de item populados com sucesso!");
+  } catch (error) {
+    console.error("Erro ao popular tipos de item:", error);
+  }
+};

--- a/prisma/seed/seed.ts
+++ b/prisma/seed/seed.ts
@@ -1,10 +1,12 @@
 import { prisma } from "../../src/libs/prisma";
 import { seedItens } from "./item";
+import { seedItemTypes } from "./itemType";
 import { seedPayments } from "./payments";
 import { seedUser } from "./user";
 
 async function seed() {
   await seedUser();
+  await seedItemTypes();
   await seedItens()
   await seedPayments()
 }

--- a/src/controllers/itemType/index.ts
+++ b/src/controllers/itemType/index.ts
@@ -1,0 +1,8 @@
+import { ItemTypeRepository } from "@/repository/prisma/itemType/itemType.prisma";
+import { ItemTypeService } from "@/service/itemType/itemType.service";
+import { ItemTypeController } from "./itemType.controller";
+
+const itemTypeRepository = new ItemTypeRepository();
+const itemTypeService = new ItemTypeService(itemTypeRepository);
+
+export const itemTypeController = new ItemTypeController(itemTypeService);

--- a/src/controllers/itemType/itemType.controller.ts
+++ b/src/controllers/itemType/itemType.controller.ts
@@ -1,0 +1,27 @@
+import { itemTypeCreateBodySchema } from "@/domain/dto/itemType/ItemTypeDto";
+import { IItemTypeService } from "@/service/itemType/IItemTypeService.type";
+import { HttpStatus } from "@/shared/constants";
+import { NextFunction, Request, Response } from "express";
+
+export class ItemTypeController {
+  constructor(private readonly itemTypeService: IItemTypeService) {}
+
+  listAll = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const data = await this.itemTypeService.listAll();
+      res.status(HttpStatus.OK).json(data);
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  create = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const dto = itemTypeCreateBodySchema.parse(req.body);
+      const data = await this.itemTypeService.create(dto);
+      res.status(HttpStatus.CREATED).json(data);
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/domain/dto/itemType/ItemTypeDto.ts
+++ b/src/domain/dto/itemType/ItemTypeDto.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+const itemTypeCreateBodySchema = z.object({
+  nome: z.string({ required_error: "O nome do tipo é obrigatório" }).min(2, "O tipo deve ter no mínimo 2 caracteres"),
+});
+
+type ItemTypeCreateDto = z.infer<typeof itemTypeCreateBodySchema>;
+
+export { itemTypeCreateBodySchema, ItemTypeCreateDto };

--- a/src/domain/dto/itens/ItensDto.ts
+++ b/src/domain/dto/itens/ItensDto.ts
@@ -1,4 +1,4 @@
-import { ItemSize, StatusItem, TypeItem } from "@prisma/client";
+import { ItemSize, StatusItem } from "@prisma/client";
 import { Decimal } from "@prisma/client/runtime/library";
 import { z } from "zod";
 
@@ -13,7 +13,7 @@ const itemCreateBodySchema = z.object({
   size: z.nativeEnum(ItemSize),
   unitPrice: z.number().optional(),
   unity: z.number().optional(),
-  type: z.nativeEnum(TypeItem),
+  itemTypeId: z.string({ required_error: "O tipo é obrigatório" }).uuid("O tipo deve ser um id válido"),
 });
 
 const itemUpdateBodySchema = z.object({
@@ -28,7 +28,7 @@ const itemUpdateBodySchema = z.object({
   size: z.nativeEnum(ItemSize).optional(),
   unitPrice: z.number().optional(),
   unity: z.number().optional(),
-  type: z.nativeEnum(TypeItem).optional(),
+  itemTypeId: z.string().uuid("O tipo deve ser um id válido").optional(),
 });
 
 type ItemCreateDto = z.infer<typeof itemCreateBodySchema>;

--- a/src/domain/model/CartEntity.ts
+++ b/src/domain/model/CartEntity.ts
@@ -1,4 +1,4 @@
-import { Carrinho, CarrinhoItens, ItemSize, StatusCart, TypeItem } from "@prisma/client";
+import { Carrinho, CarrinhoItens, ItemSize, StatusCart } from "@prisma/client";
 import { Decimal } from "@prisma/client/runtime/library";
 
 type CartEntity = Carrinho;
@@ -30,7 +30,10 @@ export interface ListCartDto extends Cart {
                 image:string | null,
                 descricao:string,
                 nome:string,
-                tipo: TypeItem | null,
+                itemType: {
+                    id: string;
+                    nome: string;
+                } | null,
                 disponivel:string | null,
             } | null;
         }

--- a/src/domain/model/ItemTypeEntity.ts
+++ b/src/domain/model/ItemTypeEntity.ts
@@ -1,0 +1,3 @@
+import { ItemType } from "@prisma/client";
+
+export type ItemTypeEntity = ItemType;

--- a/src/domain/model/OrderEntity.ts
+++ b/src/domain/model/OrderEntity.ts
@@ -1,4 +1,4 @@
-import { ItemSize, Pedido, Prisma, StatusItem, StatusOrder, TypeItem } from "@prisma/client";
+import { ItemSize, Pedido, Prisma, StatusItem, StatusOrder } from "@prisma/client";
 import { Decimal } from "@prisma/client/runtime/library";
 
 export type OrderEntity = Pedido;
@@ -76,7 +76,10 @@ export type ListOrderByIdDto = {
           id: string;
           image: string;
           nome: string;
-          tipo: TypeItem | null;
+          itemType: {
+            id: string;
+            nome: string;
+          } | null;
           disponivel: StatusItem | null;
           descricao: string | null;
         } | null;
@@ -223,7 +226,10 @@ export type ListAllOrdersDto = {
           id: string;
           image: string;
           nome: string;
-          tipo: TypeItem | null;
+          itemType: {
+            id: string;
+            nome: string;
+          } | null;
           disponivel: StatusItem | null;
           descricao: string | null;
         } | null;

--- a/src/domain/model/index.ts
+++ b/src/domain/model/index.ts
@@ -2,3 +2,4 @@ export * from "./OrderEntity";
 export * from "./ItemEntity";
 export * from "./CartEntity";
 export * from "./UserEntity";
+export * from "./ItemTypeEntity";

--- a/src/infra/server/app.ts
+++ b/src/infra/server/app.ts
@@ -9,6 +9,7 @@ import {
   orderRouter,
   paymentMethodRouter,
   dashboardRouter,
+  itemTypeRouter,
 } from "./routes";
 import { errorHandlerMiddleware } from "../../middlewares/error";
 import { shippingRouter } from "./routes/shipping/route";
@@ -64,6 +65,7 @@ export async function createApp() {
   app.use(userRouter);
   app.use(authRouter);
   app.use(itensRouter);
+  app.use(itemTypeRouter);
   app.use(cartRouter);
   app.use(orderRouter);
   app.use(shippingRouter);

--- a/src/infra/server/routes/index.ts
+++ b/src/infra/server/routes/index.ts
@@ -5,3 +5,4 @@ export * from "./cart/cart.routes";
 export * from "./order/order.routes";
 export * from "./paymentMethods/route"
 export * from "./dashboard/dashboard.route"
+export * from "./itemType/itemType.routes";

--- a/src/infra/server/routes/itemType/itemType.routes.ts
+++ b/src/infra/server/routes/itemType/itemType.routes.ts
@@ -1,0 +1,81 @@
+import { itemTypeController } from "@/controllers/itemType";
+import { jwtAtuhenticator } from "@/middlewares/authentication";
+import { authorization } from "@/middlewares/authorization";
+import { AccessProfile } from "@/shared/constants";
+import { Router } from "express";
+
+export const itemTypeRouter = Router();
+
+itemTypeRouter.get(
+  "/api/item-types",
+  /*
+    #swagger.tags = ['Item Types']
+    #swagger.summary = 'Lista todos os tipos de item cadastrados'
+    #swagger.security = [{ "bearerAuth": [] }]
+    #swagger.responses[200] = {
+      description: 'Tipos de item listados com sucesso',
+      content: {
+        "application/json": {
+          schema: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                id: { type: "string", example: "2c4b0263-250b-4b59-9475-c6858491c0eee" },
+                nome: { type: "string", example: "EMPADAO" }
+              }
+            }
+          }
+        }
+      }
+    }
+    #swagger.responses[401] = { description: 'Não autorizado' }
+  */
+  jwtAtuhenticator.authenticate,
+  authorization.anyRole().authorize,
+  itemTypeController.listAll,
+);
+
+itemTypeRouter.post(
+  "/api/item-types",
+  /*
+    #swagger.tags = ['Item Types']
+    #swagger.summary = 'Cadastra um novo tipo de item (admin)'
+    #swagger.security = [{ "bearerAuth": [] }]
+    #swagger.requestBody = {
+      required: true,
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            required: ["nome"],
+            properties: {
+              nome: { type: "string", example: "TORTA" }
+            }
+          }
+        }
+      }
+    }
+    #swagger.responses[201] = {
+      description: 'Tipo de item criado com sucesso',
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: {
+              id: { type: "string", example: "2c4b0263-250b-4b59-9475-c6858491c0eee" },
+              nome: { type: "string", example: "TORTA" }
+            }
+          }
+        }
+      }
+    }
+    #swagger.responses[400] = { description: 'Dados inválidos' }
+    #swagger.responses[401] = { description: 'Não autorizado' }
+    #swagger.responses[403] = { description: 'Sem permissão' }
+    #swagger.responses[409] = { description: 'Tipo de item já cadastrado' }
+  */
+  jwtAtuhenticator.authenticate,
+  authorization.ofRoles([AccessProfile.ADMIN]).authorize,
+  itemTypeController.create,
+);

--- a/src/infra/server/routes/itens/itens.routes.ts
+++ b/src/infra/server/routes/itens/itens.routes.ts
@@ -18,7 +18,7 @@ itensRouter.post(
         "application/json": {
           schema: {
             type: "object",
-            required: ["name", "price", "description", "image", "size", "type"],
+            required: ["name", "price", "description", "image", "size", "itemTypeId"],
             properties: {
               name:        { type: "string", example: "Pizza Margherita" },
               price:       { type: "string", example: "49.90" },
@@ -28,7 +28,7 @@ itensRouter.post(
               size:        { type: "string", enum: ["P", "M", "G", "GG"], example: "M" },
               unitPrice:   { type: "number", example: 49.90 },
               unity:       { type: "number", example: 1 },
-              type:        { type: "string", enum: ["FOOD", "DRINK", "DESSERT"], example: "FOOD" }
+              itemTypeId:  { type: "string", example: "2c4b0263-250b-4b59-9475-c6858491c0eee" }
             }
           }
         }
@@ -117,7 +117,7 @@ itensRouter.put(
               size:        { type: "string", enum: ["P", "M", "G", "GG"], example: "G" },
               unitPrice:   { type: "number", example: 55.90 },
               unity:       { type: "number", example: 1 },
-              type:        { type: "string", enum: ["FOOD", "DRINK", "DESSERT"], example: "FOOD" }
+              itemTypeId:  { type: "string", example: "2c4b0263-250b-4b59-9475-c6858491c0eee" }
             }
           }
         }

--- a/src/integration/http-routes.integration.spec.ts
+++ b/src/integration/http-routes.integration.spec.ts
@@ -3,7 +3,7 @@ import "dotenv/config";
 import type { Express } from "express";
 import request from "supertest";
 import { Decimal } from "@prisma/client/runtime/library";
-import { ItemSize, StatusCart, StatusItem, TypeItem } from "@prisma/client";
+import { ItemSize, StatusCart, StatusItem } from "@prisma/client";
 
 import { AccessProfile } from "@/shared/constants/accessProfile";
 import { createApp } from "@/infra/server/app";
@@ -342,12 +342,18 @@ async function seedItemAndPaymentMethod() {
     },
   });
 
+  const itemType = await prisma.itemType.upsert({
+    where: { nome: "EMPADAO" },
+    update: {},
+    create: { nome: "EMPADAO" },
+  });
+
   const itemDescription = await prisma.itemDescription.create({
     data: {
       nome: `Empadao-${Date.now()}`,
       descricao: "Empadao de frango especial com massa artesanal",
       image: "https://example.com/empadao.png",
-      tipo: TypeItem.EMPADAO,
+      itemTypeId: itemType.id,
       disponivel: StatusItem.ATIVO,
     },
   });

--- a/src/repository/in-memory/cart.ts
+++ b/src/repository/in-memory/cart.ts
@@ -108,7 +108,7 @@ class InMemoryCartRepository implements ICartRepository {
             image: null,
             nome: "Item mock",
             descricao: "Descrição mock",
-            tipo: null,
+            itemType: null,
             disponivel: null,
           },
         },

--- a/src/repository/in-memory/itens.ts
+++ b/src/repository/in-memory/itens.ts
@@ -1,6 +1,6 @@
 import { ItemCreateDto, ItemUpdateDto } from "@/domain/dto/itens/ItensDto";
 import { IItemsRepository } from "../interfaces/index";
-import { Item, ItemDescription, StatusCart, StatusItem, TypeItem } from "@prisma/client";
+import { Item, ItemDescription, StatusCart, StatusItem } from "@prisma/client";
 import { randomUUID } from "node:crypto";
 import { Decimal } from "@prisma/client/runtime/library";
 import { ItemDescriptionEntity, ItemEntity } from "@/domain/model";
@@ -17,7 +17,7 @@ class InMemoryItensRepository implements IItemsRepository {
       updatedAt: new Date(),
       createdAt: new Date(),
       disponivel: dto.available,
-      tipo: TypeItem.EMPADAO,
+      itemTypeId: dto.itemTypeId,
     };
     const item: ItemEntity = {
       id: randomUUID(),

--- a/src/repository/interfaces/index.ts
+++ b/src/repository/interfaces/index.ts
@@ -3,3 +3,4 @@ export * from "./cart.type";
 export * from "./itens.type";
 export * from "./order.type";
 export * from "./user.type";
+export * from "./itemType.type";

--- a/src/repository/interfaces/itemType.type.ts
+++ b/src/repository/interfaces/itemType.type.ts
@@ -1,0 +1,8 @@
+import { ItemTypeCreateDto } from "@/domain/dto/itemType/ItemTypeDto";
+import { ItemTypeEntity } from "@/domain/model/ItemTypeEntity";
+
+export interface IItemTypeRepository {
+  create: (dto: ItemTypeCreateDto) => Promise<Pick<ItemTypeEntity, "id" | "nome">>;
+  listAll: () => Promise<Pick<ItemTypeEntity, "id" | "nome">[]>;
+  findByName: (nome: string) => Promise<Pick<ItemTypeEntity, "id" | "nome"> | null>;
+}

--- a/src/repository/interfaces/user.type.ts
+++ b/src/repository/interfaces/user.type.ts
@@ -3,7 +3,7 @@ import { AddressDto, AddressUpdateDto } from "@/domain/dto/address/AddressDto";
 import { ListUserLoggedDto, UserAddressEntity, UserEntity } from "@/domain/model";
 import { CreateUserDto } from "@/domain/dto/auth/CreateUserDto";
 import { Decimal } from "@prisma/client/runtime/library";
-import { ItemSize, StatusItem, TypeItem } from "@prisma/client";
+import { ItemSize, StatusItem } from "@prisma/client";
 
 export interface UserLoggedInterface {
   id: string;
@@ -35,7 +35,10 @@ export interface UserLoggedInterface {
           id: string;
           image: string;
           nome: string;
-          tipo: TypeItem | null;
+          itemType: {
+            id: string;
+            nome: string;
+          } | null;
           disponivel: StatusItem | null;
           descricao: string | null;
         } | null;

--- a/src/repository/prisma/cart/cart.prisma.ts
+++ b/src/repository/prisma/cart/cart.prisma.ts
@@ -103,7 +103,7 @@ class CartRepository implements ICartRepository {
                 descricao: true,
                 image: true,
                 nome: true,
-                tipo: true,
+                itemType: { select: { id: true, nome: true } },
               },
             },
           },
@@ -149,7 +149,7 @@ class CartRepository implements ICartRepository {
               select: {
                 image: true,
                 nome: true,
-                tipo: true,
+                itemType: { select: { id: true, nome: true } },
                 descricao: true,
                 id: true,
                 disponivel: true,

--- a/src/repository/prisma/itemType/itemType.prisma.ts
+++ b/src/repository/prisma/itemType/itemType.prisma.ts
@@ -1,0 +1,41 @@
+import { ItemTypeCreateDto } from "@/domain/dto/itemType/ItemTypeDto";
+import { prisma } from "@/libs/prisma";
+import { IItemTypeRepository } from "@/repository/interfaces/itemType.type";
+
+export class ItemTypeRepository implements IItemTypeRepository {
+  create = async (dto: ItemTypeCreateDto) => {
+    return await prisma.itemType.create({
+      data: {
+        nome: dto.nome,
+      },
+      select: {
+        id: true,
+        nome: true,
+      },
+    });
+  };
+
+  listAll = async () => {
+    return await prisma.itemType.findMany({
+      orderBy: {
+        nome: "asc",
+      },
+      select: {
+        id: true,
+        nome: true,
+      },
+    });
+  };
+
+  findByName = async (nome: string) => {
+    return await prisma.itemType.findUnique({
+      where: {
+        nome,
+      },
+      select: {
+        id: true,
+        nome: true,
+      },
+    });
+  };
+}

--- a/src/repository/prisma/itens/itens.prisma.ts
+++ b/src/repository/prisma/itens/itens.prisma.ts
@@ -14,7 +14,9 @@ class ItemRepository implements IItemsRepository {
           disponivel: dto.available,
           createdAt: new Date(),
           updatedAt: new Date(),
-          tipo: dto.type,
+          itemType: {
+            connect: { id: dto.itemTypeId },
+          },
         },
         include: {
           item: true,
@@ -43,7 +45,7 @@ class ItemRepository implements IItemsRepository {
         image: true,
         descricao: true,
         disponivel: true,
-        tipo: true,
+        itemType: { select: { id: true, nome: true } },
         item: {
           select: {
             id: true,
@@ -68,7 +70,7 @@ class ItemRepository implements IItemsRepository {
         itemDescription: {
           select: {
             nome: true,
-            tipo: true,
+            itemType: { select: { id: true, nome: true } },
             id: true,
             descricao: true,
             disponivel: true,
@@ -93,7 +95,7 @@ class ItemRepository implements IItemsRepository {
         image: true,
         descricao: true,
         disponivel: true,
-        tipo: true,
+        itemType: { select: { id: true, nome: true } },
         item: {
           select: {
             id: true,
@@ -115,7 +117,7 @@ class ItemRepository implements IItemsRepository {
         image: true,
         descricao: true,
         disponivel: true,
-        tipo: true,
+        itemType: { select: { id: true, nome: true } },
         item: {
           select: {
             id: true,
@@ -142,6 +144,11 @@ class ItemRepository implements IItemsRepository {
             nome: dto.name,
             image: dto.image,
             updatedAt: new Date(),
+            ...(dto.itemTypeId && {
+              itemType: {
+                connect: { id: dto.itemTypeId },
+              },
+            }),
           },
         },
       },
@@ -182,7 +189,11 @@ class ItemRepository implements IItemsRepository {
         precoUnitario: true,
         tamanho: true,
         preco: true,
-        itemDescription: true,
+        itemDescription: {
+          include: {
+            itemType: true,
+          },
+        },
         itemDescriptionId: true,
         unidades: true,
       },
@@ -196,7 +207,7 @@ class ItemRepository implements IItemsRepository {
         disponivel: true,
         image: true,
         id: true,
-        tipo: true,
+        itemType: { select: { id: true, nome: true } },
         nome: true,
         descricao: true,
         item: true,

--- a/src/repository/prisma/order/order.prisma.ts
+++ b/src/repository/prisma/order/order.prisma.ts
@@ -215,7 +215,7 @@ class OrderRepository implements IOrderRepository {
                     itemDescription: {
                       select: {
                         nome: true,
-                        tipo: true,
+                        itemType: { select: { id: true, nome: true } },
                         descricao: true,
                       },
                     },
@@ -335,7 +335,7 @@ class OrderRepository implements IOrderRepository {
                           id: true,
                           image: true,
                           nome: true,
-                          tipo: true,
+                          itemType: { select: { id: true, nome: true } },
                           disponivel: true,
                           descricao: true,
                         },
@@ -421,7 +421,7 @@ class OrderRepository implements IOrderRepository {
                         id: true,
                         image: true,
                         nome: true,
-                        tipo: true,
+                        itemType: { select: { id: true, nome: true } },
                         disponivel: true,
                         descricao: true,
                       },

--- a/src/service/cart/Cart.service.ts
+++ b/src/service/cart/Cart.service.ts
@@ -3,7 +3,7 @@ import { ICartService } from "./ICartService.type";
 import { ICartRepository } from "@/repository/interfaces/index";
 import { IItemsRepository } from "@/repository/interfaces";
 import { BadRequestException } from "@/shared/error/exceptions/badRequest-exception";
-import { StatusItem, TypeItem } from "@prisma/client";
+import { StatusItem } from "@prisma/client";
 import { ListCartDto } from "@/domain/model";
 
 class CartService implements ICartService {
@@ -18,8 +18,7 @@ class CartService implements ICartService {
       throw new BadRequestException("Item não encontrado ou Inativo!");
     }
 
-    const notIsPie = foundItem.itemDescription!.tipo !== TypeItem.EMPADAO ? true : false;
-    const priceItemByType = !notIsPie ? foundItem.preco : foundItem.precoUnitario!;
+    const priceItemByType = foundItem.unidades ? foundItem.precoUnitario! : foundItem.preco;
 
     const cartAlredyExist = await this.cartRepository.findCartActiveByUser(idUser);
 

--- a/src/service/cart/CartService.spec.ts
+++ b/src/service/cart/CartService.spec.ts
@@ -4,7 +4,7 @@ import { CartService } from "@/service/cart/Cart.service";
 import { ItemCreateDto } from "@/domain/dto/itens/ItensDto";
 import { CreateUserDto } from "@/domain/dto/auth/CreateUserDto";
 import { AccessProfile } from "@/shared/constants";
-import { Item, ItemSize, StatusCart, StatusItem, TypeItem, Usuario } from "@prisma/client";
+import { Item, ItemSize, StatusCart, StatusItem, Usuario } from "@prisma/client";
 import { InMemoryUserRepository } from "@/repository/in-memory/user";
 import { CreateCartDto } from "@/domain/dto/cart/CreateCartDto";
 import { randomUUID } from "node:crypto";
@@ -39,7 +39,7 @@ describe("Unit test - cartService", () => {
     image: "https://exemplo.com/imagem.jpg",
     available: StatusItem.ATIVO,
     size: ItemSize.M,
-    type: TypeItem.EMPADAO,
+    itemTypeId: randomUUID(),
     ...overrides,
   });
 
@@ -86,7 +86,7 @@ describe("Unit test - cartService", () => {
           available: StatusCart.ATIVO,
           name: "Empadão de camarão",
           price: new Decimal(50),
-          type: TypeItem.EMPADAO,
+          itemTypeId: randomUUID(),
         }),
       );
       const cartDto = createCartDto({ itemId: newItem.id, quantity: 2 });

--- a/src/service/itemType/IItemTypeService.type.ts
+++ b/src/service/itemType/IItemTypeService.type.ts
@@ -1,0 +1,7 @@
+import { ItemTypeCreateDto } from "@/domain/dto/itemType/ItemTypeDto";
+import { ItemTypeEntity } from "@/domain/model/ItemTypeEntity";
+
+export interface IItemTypeService {
+  create: (dto: ItemTypeCreateDto) => Promise<Pick<ItemTypeEntity, "id" | "nome">>;
+  listAll: () => Promise<Pick<ItemTypeEntity, "id" | "nome">[]>;
+}

--- a/src/service/itemType/itemType.service.ts
+++ b/src/service/itemType/itemType.service.ts
@@ -1,0 +1,27 @@
+import { ItemTypeCreateDto } from "@/domain/dto/itemType/ItemTypeDto";
+import { IItemTypeRepository } from "@/repository/interfaces/itemType.type";
+import { ConflitException } from "@/shared/error/exceptions/conflit-exception";
+import { IItemTypeService } from "./IItemTypeService.type";
+
+export class ItemTypeService implements IItemTypeService {
+  constructor(private readonly itemTypeRepository: IItemTypeRepository) {}
+
+  create = async (dto: ItemTypeCreateDto) => {
+    const normalizedDto = {
+      ...dto,
+      nome: dto.nome.trim().toUpperCase(),
+    };
+
+    const itemTypeAlreadyExists = await this.itemTypeRepository.findByName(normalizedDto.nome);
+
+    if (itemTypeAlreadyExists) {
+      throw new ConflitException("Tipo de item já cadastrado");
+    }
+
+    return await this.itemTypeRepository.create(normalizedDto);
+  };
+
+  listAll = async () => {
+    return await this.itemTypeRepository.listAll();
+  };
+}

--- a/src/service/itens/ItemService.spec.ts
+++ b/src/service/itens/ItemService.spec.ts
@@ -3,7 +3,8 @@ import { InMemoryItensRepository } from "@/repository/in-memory/itens";
 import { ItensService } from "./itens.service";
 import { ItemCreateDto } from "@/domain/dto/itens/ItensDto";
 import { Decimal } from "@prisma/client/runtime/library";
-import { ItemSize, StatusCart, StatusItem, TypeItem } from "@prisma/client";
+import { ItemSize, StatusCart, StatusItem } from "@prisma/client";
+import { randomUUID } from "node:crypto";
 
 describe("Units Test - Item", () => {
   let itemMemoryRepository: InMemoryItensRepository;
@@ -22,7 +23,7 @@ describe("Units Test - Item", () => {
       image: "https://exemplo.com/imagem.jpg",
       available: StatusItem.ATIVO,
       size: ItemSize.M,
-      type: TypeItem.EMPADAO,
+      itemTypeId: randomUUID(),
       ...overrides,
     };
   };

--- a/src/swagger-output.json
+++ b/src/swagger-output.json
@@ -618,7 +618,7 @@
                   "description",
                   "image",
                   "size",
-                  "type"
+                  "itemTypeId"
                 ],
                 "properties": {
                   "name": {
@@ -663,14 +663,9 @@
                     "type": "number",
                     "example": 1
                   },
-                  "type": {
+                  "itemTypeId": {
                     "type": "string",
-                    "enum": [
-                      "FOOD",
-                      "DRINK",
-                      "DESSERT"
-                    ],
-                    "example": "FOOD"
+                    "example": "2c4b0263-250b-4b59-9475-c6858491c0eee"
                   }
                 }
               }
@@ -828,14 +823,9 @@
                     "type": "number",
                     "example": 1
                   },
-                  "type": {
+                  "itemTypeId": {
                     "type": "string",
-                    "enum": [
-                      "FOOD",
-                      "DRINK",
-                      "DESSERT"
-                    ],
-                    "example": "FOOD"
+                    "example": "2c4b0263-250b-4b59-9475-c6858491c0eee"
                   }
                 }
               }
@@ -1554,6 +1544,113 @@
             "bearerAuth": []
           }
         ]
+      }
+    },
+    "/api/item-types": {
+      "get": {
+        "tags": [
+          "Item Types"
+        ],
+        "summary": "Lista todos os tipos de item cadastrados",
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "Tipos de item listados com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "example": "2c4b0263-250b-4b59-9475-c6858491c0eee"
+                      },
+                      "nome": {
+                        "type": "string",
+                        "example": "EMPADAO"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Não autorizado"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Item Types"
+        ],
+        "summary": "Cadastra um novo tipo de item (admin)",
+        "description": "",
+        "responses": {
+          "201": {
+            "description": "Tipo de item criado com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "example": "2c4b0263-250b-4b59-9475-c6858491c0eee"
+                    },
+                    "nome": {
+                      "type": "string",
+                      "example": "TORTA"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Não autorizado"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "409": {
+            "description": "Tipo de item já cadastrado"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "nome"
+                ],
+                "properties": {
+                  "nome": {
+                    "type": "string",
+                    "example": "TORTA"
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/shipping": {

--- a/swagger.ts
+++ b/swagger.ts
@@ -41,6 +41,7 @@ const endpointsFiles = [
   "./src/infra/server/routes/cart/cart.routes.ts",
   "./src/infra/server/routes/order/order.routes.ts",
   "./src/infra/server/routes/paymentMethods/route.ts",
+  "./src/infra/server/routes/itemType/itemType.routes.ts",
   "./src/infra/server/routes/shipping/route.ts",
   "./src/infra/server/routes/dashboard/dashboard.route.ts",
 ];


### PR DESCRIPTION
### Motivation
- Replace the rigid `TypeItem` enum with a dynamic `ItemType` table so item types can be managed at runtime instead of compile-time.
- Migrate existing enum values into the database and preserve relationships on `ItemDescription`.
- Expose CRUD endpoints and services to manage item types and update all consumers to use `itemTypeId` references.

### Description
- Database: added migration `prisma/migrations/20260515120000_replace_type_item_with_item_type/migration.sql` that creates `item_types`, migrates distinct `ItemDescription.tipo` values into `item_types`, links `ItemDescription.itemTypeId`, drops the old `tipo` column and `TypeItem` enum, and adds the foreign key.
- Prisma schema: removed `TypeItem` enum and added `ItemType` model with `@@map("item_types")` and a `itemTypeId` relation on `ItemDescription`.
- Seeding: added `prisma/seed/itemType.ts` and updated `prisma/seed/item.ts` to `connectOrCreate` `itemType` entries; updated `seed.ts` to call `seedItemTypes`.
- API and routing: added item type controller, service, repository, DTOs, routes (`/api/item-types`) and swagger docs; wired `itemTypeRouter` into the app and swagger generation.
- Repositories/Services/Models/DTOs: updated all repository selects and service logic to use `itemType` relations instead of `tipo`/`TypeItem`; changed DTOs to accept `itemTypeId` (UUID) for item creation/updating; added `ItemType` domain model and interfaces (`IItemTypeRepository`, `IItemTypeService`).
- In-memory/test updates: updated in-memory repositories, unit tests, and integration tests to remove enum usage and use `itemTypeId` or seeded `itemType` records; adjusted cart pricing logic to not rely on `TypeItem`.

### Testing
- Ran the test suites with `jest` including unit tests and integration tests (`npm test` / `yarn test`), and all tests completed successfully.
- Performed a TypeScript build/check and the project compiles without errors.
- Verified seed flow locally by running the prisma seed script and confirming `item_types` are created and `ItemDescription` records link to `itemTypeId`.
- Confirmed API routes generation updated `swagger-output.json` and the new `/api/item-types` endpoints appear in the docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0795924060832c8c106a42aae1f1cb)